### PR TITLE
Add check for undefined variable

### DIFF
--- a/lib/parser/title.js
+++ b/lib/parser/title.js
@@ -70,7 +70,7 @@ function getTitleFromMetaTags(rawHtml) {
     }
   }
 
-  if (siteName) {
+  if (siteName && title) {
     title = removeSiteNameFromTitle(title, siteName);
   }
 


### PR DESCRIPTION
Passing an undefined title to removeSiteNameFromTitle causes an error so I have added a check.
